### PR TITLE
Call docker_push script correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,6 @@ addons:
 
 deploy:
   provider: script
-  script: bash docker_push
+  script: bash ./docker_push.sh
   on:
     branch: master


### PR DESCRIPTION
Attempting to fix this failing deploy on travis. The error is 
`bash: docker_push: No such file or directory`.