### PR TITLE
Fix failing jest run

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
       "<rootDir>/tests/*"
     ],
     "transformIgnorePatterns": [
-      "<rootDir>/node_modules/"
+      "/node_modules/(?!(ol|labelgun|mapbox-to-ol-style|ol-mapbox-style)/).*/"
     ]
   },
   "eslintConfig": {


### PR DESCRIPTION
The problem is caused by node.js which doesn't support es2015 module system and tests are running on node.js