### PR TITLE
better responsiveness (tags on story preview card)

### DIFF
--- a/src/components/generalComponents/StoryPreview.css
+++ b/src/components/generalComponents/StoryPreview.css
@@ -35,6 +35,8 @@
 }
 .story-wrapper .story-detail header {
   margin-bottom: 8px;
+  display: flex;
+  padding-right: 21px;
 }
 .story-wrapper .story-detail header span {
   text-transform: capitalize;
@@ -44,7 +46,7 @@
   border-radius: 2px;
   padding: 1px 5px;
   display: inline-block;
-  max-width: 30%;
+  max-width: 40%;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow-x: hidden;
@@ -60,15 +62,6 @@
   font-size: 14px;
   font-weight: 300;
 }
-
-/* THEO'S CHANGE */
-.story-title {
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-}
-/* ------------- */
-
 .story-wrapper .story-detail .story-hyperlink,
 .story-wrapper .story-detail .story-post-info {
   width: 100%;

--- a/src/components/generalComponents/StoryPreview.js
+++ b/src/components/generalComponents/StoryPreview.js
@@ -55,12 +55,12 @@ export default function StoryPreview({
         },
       }
     )
-      .then(() => {
-        removeStory();
-      })
-      .catch((error) => {
-        console.log(error);
-      });
+    .then(() => {
+      removeStory();
+    })
+    .catch((error) => {
+      console.log(error);
+    });
   }
   return (
     <>

--- a/src/components/generalComponents/StoryPreview.landing.css
+++ b/src/components/generalComponents/StoryPreview.landing.css
@@ -11,6 +11,11 @@
 .landing-story-wrapper .story-detail article p:not(:last-child) {
   margin-bottom: 10px;
 }
+.landing-story-wrapper .story-title {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
 .landing-story-wrapper .story-detail .story-description {
   max-height: 3.6rem;
   background: linear-gradient(

--- a/src/components/generalComponents/StoryPreview.profile.css
+++ b/src/components/generalComponents/StoryPreview.profile.css
@@ -16,6 +16,11 @@
 .profile-story-wrapper .story-detail article p:not(:last-child) {
   margin-bottom: 10px;
 }
+.profile-story-wrapper .story-title {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
 .profile-story-wrapper .story-detail .story-description {
   max-height: 3.6rem;
   background: linear-gradient(

--- a/src/components/loginComponents/Profile.css
+++ b/src/components/loginComponents/Profile.css
@@ -79,6 +79,7 @@
   width: 100%;
   border-radius: 4px;
   padding: 1rem;
+  margin-bottom: 1rem;
 }
 
 .story-list .loading {

--- a/src/components/loginComponents/Profile.js
+++ b/src/components/loginComponents/Profile.js
@@ -52,6 +52,13 @@ export default function Profile() {
         {/* User Stories and Post Story */}
         <h2>My stories</h2>
         <div className="personal story-list">
+          <div
+            className="post-form"
+            onClick={() => setOpenPostStoryForm(true)}
+          >
+            <img src={plusIcon} alt="post story icon" />
+            <p>post a story</p>
+          </div>
           {myStories.map((story, index) => (
             <StoryPreview
               key={story.story_id}
@@ -72,13 +79,6 @@ export default function Profile() {
               cssScope="profile"
             />
           ))}
-          <div
-            className="post-form"
-            onClick={() => setOpenPostStoryForm(true)}
-          >
-            <img src={plusIcon} alt="post story icon" />
-            <p>post a story</p>
-          </div>
         </div>
         {/* Trending Stories */}
         <h2>Trending</h2>


### PR DESCRIPTION
### Change type:
- Bug fix

### Description:
- The sector/strategy/media type tags at the top of story cards are responsive in a better way.
- Theo's fix applied to only landing/profile/stories page. Not to map (because map only has verticle story card view).
- Post a story button is now above the posted stories.

Take a look, guys. We need a new release ASAP.
