### PR TITLE
Fix map zoom implementation

### DIFF
--- a/src/components/mapsComponents/OlMap.js
+++ b/src/components/mapsComponents/OlMap.js
@@ -149,20 +149,15 @@ class OlMap extends Component {
         }
       ));
 
-      // Find target place to highlight on map
-      // Get the target place search ID
-      let targetId = this.props.targetPlace.properties.place_id;
-      this.props.places.forEach(feature => {
-        // Look for the feature that represents the searched place
-        if (feature.values_.place_id === targetId) {
-          let targetCoordinates = feature.values_.geometry.flatCoordinates;
-          let view = this.state.map.getView();
+      // Find target place coordinates to highlight on map
+      let targetLonLat = this.props.targetPlace.geometry.coordinates;
+      let targetCoordinates = fromLonLat(targetLonLat);
+      let view = this.state.map.getView();
 
-          // Center map on searched for place and zoom in
-          view.setCenter(targetCoordinates);
-          view.setZoom(4.5);
-        }
-      });
+      // Center map on searched for place and zoom in
+      view.setCenter(targetCoordinates);
+      view.setZoom(4.5);
+
     }
     if (this.props.baseMap != prevProps.baseMap) {
       this.state.map.getLayers().forEach((ele, index, arr) => {

--- a/src/components/mapsComponents/helpers/olStyles.js
+++ b/src/components/mapsComponents/helpers/olStyles.js
@@ -1,6 +1,7 @@
 import { Fill, Stroke, Circle, Style, Text } from 'ol/style';
 
 /* Styles */
+const singleFeatureSize = 8;
 
 // Allows for dynamic style choice based on type and cluster size
 let styleCache = {};
@@ -15,16 +16,16 @@ const primaryStyle = feature => {
     if (!(numInCluster in styleCache)) {
         // Determine a radius size
         let radius;
-        let baseVal = 6;
+        let clusterBaseSize = 7;
         let test = numInCluster / 10;
         if (numInCluster === 1) {        // single feature point
-            radius = baseVal;
+            radius = singleFeatureSize;
         } else if (test < 1) {          // number is < 10
-            radius = baseVal * 2;
+            radius = clusterBaseSize * 2;
         } else if (test < 10) {         // number is < 100
-            radius = baseVal * 3;
+            radius = clusterBaseSize * 3;
         } else {                        // number is >= 100
-            radius = baseVal * 4;
+            radius = clusterBaseSize * 4;
         }
 
         // Create basic Point style
@@ -54,7 +55,7 @@ const primaryStyle = feature => {
 const targetStyle = feature => {
     return new Style({
         image: new Circle({
-            radius: 6,
+            radius: singleFeatureSize,
             // If this is changed, it should also be changed in StoryDashboard.css
             fill: new Fill({ color: 'rgb(66, 173, 16)' }),
             stroke: new Stroke({ color: 'rgba(0, 0, 0, 0.5)', width: 0.5 }),

--- a/src/components/mapsComponents/helpers/popupHandler.js
+++ b/src/components/mapsComponents/helpers/popupHandler.js
@@ -20,19 +20,16 @@ export const popUpHandler = (
   let pixel = evt.pixel;
   let features = map.getFeaturesAtPixel(pixel);
 
-  // Ignore clicks on map that aren't on a feature
-  if (features.length === 0) {
+  // Get places contained in area of click
+  let places = [];
+  if (!features || features.length === 0) {
+    // No features => close any open popups and return
     overlay.setPosition(undefined);
     return;
-  }
-
-  // Get places contained in the feature list
-  let featureList = map.getFeaturesAtPixel(pixel);
-  let places = [];
-  if (featureList.length === 1) {
+  } else if (features.length === 1) {
     // Use the first element in the list if the place is not
     // the targetPlace.
-    places = featureList[0].getProperties().features;
+    places = features[0].getProperties().features;
   } else {
     // If the place is the target place, there will be more than
     // one element due to the combination of the main places layer
@@ -40,7 +37,7 @@ export const popUpHandler = (
     // place layer will be the first element in the featuresList
     // and will cause an error if clicked on because it is not
     // a clustered layer and has no features property.
-    places = featureList[1].getProperties().features;
+    places = features[1].getProperties().features;
   }
 
   // Set a div for popup content


### PR DESCRIPTION
### Change type:
- Bug fix

### Description:
- Changes the map zoom on search implementation to always work
  - Relies on target place props instead of list of places

### Steps to Verify This PR
- Try searching on the map for Seattle: Before it didn't zoom to Seattle, now it should

### Known issues
- Clicking on the target place may break the site if that place was not returned in the list of similar places. This is due to GeoServer only returning a maximum of 200 places from a search. Working on this with @nem1230 
